### PR TITLE
04-vue-cli tasks group (01-UiFormGroup1, 02-TheToaster, 03-UiDropdown…

### DIFF
--- a/04-vue-cli/01-UiFormGroup1/components/UiFormGroup.vue
+++ b/04-vue-cli/01-UiFormGroup1/components/UiFormGroup.vue
@@ -1,14 +1,27 @@
 <template>
-  <div class="form-group">
+  <div class="form-group" :class="{ 'form-group_inline': inline }">
     <!-- form-group_inline -->
-    <label class="form-group__label">label text</label>
+    <label v-if="label" class="form-group__label">
+      {{ label }}
+    </label>
     <!-- CONTENT -->
+    <slot />
   </div>
 </template>
 
 <script>
 export default {
   name: 'UiFormGroup',
+  props: {
+    inline: {
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      type: String,
+      default: '',
+    },
+  },
 };
 </script>
 

--- a/04-vue-cli/02-TheToaster/components/TheToaster.vue
+++ b/04-vue-cli/02-TheToaster/components/TheToaster.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="toasts">
-    <div class="toast toast_success">
+    <template v-for="toast in toasts" :key="toast">
+      <ui-toast :toast="toast">
+        <span @click="this.delete(toast)">{{ toast.text }}</span>
+      </ui-toast>
+    </template>
+    <!-- <div class="toast toast_success">
       <ui-icon class="toast__icon" icon="check-circle" />
       <span>Success Toast Example</span>
     </div>
@@ -8,17 +13,61 @@
     <div class="toast toast_error">
       <ui-icon class="toast__icon" icon="alert-circle" />
       <span>Error Toast Example</span>
-    </div>
+    </div> -->
   </div>
 </template>
 
 <script>
 import UiIcon from './UiIcon';
+import UiToast from './UiToast';
 
 export default {
   name: 'TheToaster',
-
-  components: { UiIcon },
+  components: { UiIcon, UiToast },
+  data() {
+    return {
+      toasts: [],
+    };
+  },
+  methods: {
+    add({
+      definingClass = 'toast_success',
+      icon = 'check-circle',
+      text = 'Text Toast Example',
+      timerDelete = 5000,
+    } = {}) {
+      const toast = {
+        definingClass,
+        icon,
+        text,
+      };
+      const index = this.toasts.push(toast) - 1;
+      const toastRef = this.toasts[index];
+      toastRef.timerId = setTimeout(() => {
+        this.delete(toastRef);
+      }, timerDelete);
+    },
+    delete(toast) {
+      const index = this.toasts.findIndex((item) => item === toast);
+      this.toasts.splice(index, 1);
+      const { timerId } = toast;
+      clearTimeout(timerId);
+    },
+    success(text) {
+      this.add({
+        definingClass: 'toast_success',
+        icon: 'check-circle',
+        text,
+      });
+    },
+    error(text) {
+      this.add({
+        definingClass: 'toast_error',
+        icon: 'alert-circle',
+        text,
+      });
+    },
+  },
 };
 </script>
 
@@ -33,41 +82,13 @@ export default {
   white-space: pre-wrap;
   z-index: 999;
 }
-
 @media all and (min-width: 992px) {
   .toasts {
     bottom: 72px;
     right: 112px;
   }
 }
-
-.toast {
-  display: flex;
-  flex: 0 0 auto;
-  flex-direction: row;
-  align-items: center;
-  padding: 16px;
-  background: #ffffff;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
-  font-size: 18px;
-  line-height: 28px;
-  width: auto;
-}
-
 .toast + .toast {
   margin-top: 20px;
-}
-
-.toast__icon {
-  margin-right: 12px;
-}
-
-.toast.toast_success {
-  color: var(--green);
-}
-
-.toast.toast_error {
-  color: var(--red);
 }
 </style>

--- a/04-vue-cli/02-TheToaster/components/UiToast.vue
+++ b/04-vue-cli/02-TheToaster/components/UiToast.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="toast" :class="toast.definingClass">
+    <ui-icon class="toast__icon" :icon="toast.icon" />
+    <slot />
+  </div>
+</template>
+
+<script>
+import UiIcon from './UiIcon.vue';
+
+export default {
+  name: 'UiToast',
+  components: { UiIcon },
+  props: {
+    toast: {
+      type: Object,
+      require: true,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.toast {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: row;
+  align-items: center;
+  padding: 16px;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  font-size: 18px;
+  line-height: 28px;
+  width: auto;
+}
+.toast__icon {
+  margin-right: 12px;
+}
+.toast.toast_success {
+  color: var(--green);
+}
+.toast.toast_error {
+  color: var(--red);
+}
+</style>

--- a/04-vue-cli/03-UiDropdown1/__tests__/UiDropdown1.test.js
+++ b/04-vue-cli/03-UiDropdown1/__tests__/UiDropdown1.test.js
@@ -147,8 +147,6 @@ describe('vue-cli/UiDropdown1', () => {
 
     // Раскомментируйте блок ниже, если решаете дополнительную часть задачи
 
-    /*
-
     it('UiDropdown должен иметь <select> со списком вариантов <option> в соответствии с параметром options', () => {
       const wrapper = mount(UiDropdown, {
         props: { options: OPTIONS, title: TITLE },
@@ -180,7 +178,5 @@ describe('vue-cli/UiDropdown1', () => {
       expect(wrapper.emitted('update:modelValue').length).toBe(1);
       expect(wrapper.emitted('update:modelValue')[0]).toEqual([OPTIONS[1].value]);
     });
-
-     */
   });
 });

--- a/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
+++ b/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
@@ -1,21 +1,30 @@
 <template>
-  <div class="dropdown dropdown_opened">
-    <button type="button" class="dropdown__toggle dropdown__toggle_icon">
-      <ui-icon icon="tv" class="dropdown__icon" />
-      <span>Title</span>
+  <div class="dropdown" :class="{ dropdown_opened: isOpened }" @click="isOpened = !isOpened">
+    <button type="button" class="dropdown__toggle" :class="{ dropdown__toggle_icon: hasIcon }">
+      <ui-icon v-if="selected.icon" :icon="selected.icon" class="dropdown__icon" />
+      <span>{{ buttonText }}</span>
     </button>
 
-    <div class="dropdown__menu" role="listbox">
-      <button class="dropdown__item dropdown__item_icon" role="option" type="button">
-        <ui-icon icon="tv" class="dropdown__icon" />
-        Option 1
-      </button>
-      <button class="dropdown__item dropdown__item_icon" role="option" type="button">
-        <ui-icon icon="tv" class="dropdown__icon" />
-        Option 2
+    <div v-show="isOpened" class="dropdown__menu" role="listbox">
+      <button
+        v-for="option in options"
+        :key="option"
+        class="dropdown__item"
+        :class="{ dropdown__item_icon: hasIcon }"
+        role="option"
+        type="button"
+        @click="select(option)"
+      >
+        <ui-icon v-if="option.icon" :icon="option.icon" class="dropdown__icon" />
+        {{ option.text }}
       </button>
     </div>
   </div>
+  <select v-show="false" :value="modelValue" @change="change">
+    <option v-for="option in options" :key="option" :value="option.value">
+      {{ option.text }}
+    </option>
+  </select>
 </template>
 
 <script>
@@ -25,6 +34,47 @@ export default {
   name: 'UiDropdown',
 
   components: { UiIcon },
+
+  props: {
+    modelValue: String,
+    title: {
+      type: String,
+      require: true,
+    },
+    options: {
+      type: Array,
+      require: true,
+    },
+  },
+
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      isOpened: false,
+    };
+  },
+  computed: {
+    selected() {
+      if (this.modelValue) {
+        return this.options.find((item) => item.value === this.modelValue) || {};
+      }
+      return {};
+    },
+    buttonText() {
+      return this.selected?.text || this.title;
+    },
+    hasIcon() {
+      return Boolean(this.options.find((item) => item.icon));
+    },
+  },
+  methods: {
+    select(option) {
+      this.$emit('update:modelValue', option.value);
+    },
+    change(event) {
+      this.select(event.target);
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
В задаче 02-TheToaster в компоненте TheToaster.vue решил поэкспериментировать со слотом, а также создать событие удаления при клике по слоту. Как бы если в слот передать верстку с "крестиком", то на крестик можно повешать такое событие. При этом UiToast компонент ничего знать об этом не будет. Но вопрос, почему в инлайновое событие, расположенное внутри слота, пришлось передать событие через this, вот так:
`<span @click="this.delete(toast)">{{ toast.text }}</span>`
Почему вот такой вариант не сработал:
`<span @click="delete(toast)">{{ toast.text }}</span>`
Догадываюсь, что это как то связано с тем, что слот передается в UiToast.